### PR TITLE
Extract the dependency on electron logic (e.g showing a dialog) as dialogService

### DIFF
--- a/redux/src/main/renderer/containers/AppContainer.js
+++ b/redux/src/main/renderer/containers/AppContainer.js
@@ -2,9 +2,9 @@ import _ from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { remote } from 'electron'
 import * as appActions from '../actions/app';
 import SideMenuContainer from '../containers/SideMenuContainer';
+import * as dialogService from '../registries/dialogService';
 
 class AppContainer extends Component {
   componentDidMount() {
@@ -17,7 +17,7 @@ class AppContainer extends Component {
     const { errorMessage } = this.props;
 
     if (errorMessage.content) {
-      remote.dialog.showErrorBox(errorMessage.title, errorMessage.content);
+      dialogService.showErrorDialog({ title: errorMessage.title, body: errorMessage.content });
     }
   }
 

--- a/redux/src/main/renderer/containers/prefrence/PreferencesContainer.js
+++ b/redux/src/main/renderer/containers/prefrence/PreferencesContainer.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { ipcRenderer } from 'electron';
 import React, { Component, PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -7,6 +6,7 @@ import EditableList from '../../components/EditableList';
 import IconNameItem from '../../components/IconNameItem';
 import { Accounts } from '../../../domain/models/Accounts'
 import * as accountActions from '../../actions/account';
+import * as dialogService from '../../registries/dialogService';
 
 class PreferencesContainer extends Component {
 
@@ -24,8 +24,7 @@ class PreferencesContainer extends Component {
   _onAddAccount() {
     const { fetchAccount } = this.props.actions;
 
-    ipcRenderer.send('add-account');
-    ipcRenderer.on('added-account', (event, credential) => {
+    dialogService.addAccount((credential) => {
       fetchAccount(credential, false);
     });
   }

--- a/redux/src/main/renderer/registries/dialogService.js
+++ b/redux/src/main/renderer/registries/dialogService.js
@@ -1,0 +1,1 @@
+export * from './electron/dialogServiceImpl'

--- a/redux/src/main/renderer/registries/electron/dialogServiceImpl.js
+++ b/redux/src/main/renderer/registries/electron/dialogServiceImpl.js
@@ -1,0 +1,12 @@
+import { remote, ipcRenderer } from 'electron'
+
+export const showErrorDialog = ({ title, body }) => {
+  remote.dialog.showErrorBox(title, body);
+};
+
+export const addAccount = (onAddedAccount) => {
+  ipcRenderer.send('add-account');
+  ipcRenderer.on('added-account', (event, credential) => {
+    onAddedAccount(credential);
+  });
+};


### PR DESCRIPTION
We can reuse containers in other platform by changing dialogService logic